### PR TITLE
Option to filter based on Group

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -41,6 +41,19 @@ module.exports = {
             return modifier(track, sourceActual, collected);
         }
     },
+    
+    
+    forGroup: function(group, modifier){
+        return function(track, source, collected){
+            ensureTrackParams(track);
+            if (group != track.params['group-title']){
+                return track;
+            }
+
+            return modifier(track, group, collected);
+        }
+    },
+
 
     // track modifiers
     remove: function(){


### PR DESCRIPTION
With this change you can set a filter to do something based on the original group of the item.  For example if your source m3u labels some channels as 'Sport' you can set a filter to change the group to 'Action' etc.  It may be possible to use a wildcard * as well which would be cool but I haven't tested this yet.